### PR TITLE
Fix camera positioning

### DIFF
--- a/VRTweaks/CameraPositionFixes.cs
+++ b/VRTweaks/CameraPositionFixes.cs
@@ -1,0 +1,27 @@
+﻿using UnityEngine;
+using HarmonyLib;
+
+namespace VRTweaks
+{
+    class CameraPositionFixes
+    {
+
+        // In the base game, the camera position is shifted backwards behind the neck while
+        // the PDA is not out, and when the PDA is out, it is shifted forwards to the "proper" location.
+        // This patch keeps the camera position aligned on the center of the player body always.
+        // A side effect is that it also no longer causes the player body to be clipped at the value
+        // it was by default, so looking down you can see the body without clipping.
+        [HarmonyPatch(typeof(MainCameraControl), nameof(MainCameraControl.LateUpdate))]
+        class CameraForwardPosition_Patch
+        {
+            static bool Prefix(MainCameraControl __instance)
+            {
+                __instance.cameraUPTransform.localPosition
+                    = new Vector3(__instance.cameraUPTransform.localPosition.x, __instance.cameraUPTransform.localPosition.y, 0f);
+                return false;
+            }
+
+        }
+
+    }
+}

--- a/VRTweaks/VRTweaks.csproj
+++ b/VRTweaks/VRTweaks.csproj
@@ -101,6 +101,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BubblesSubtitleFixer.cs" />
+    <Compile Include="CameraPositionFixes.cs" />
     <Compile Include="GazeLayerFix.cs" />
     <Compile Include="VolumeCloudPatches.cs" />
     <Compile Include="SnapTurn\SnapTurningMenu.cs" />


### PR DESCRIPTION
Without this patch, the camera is positioned just behind the player's
neck normally. When the player would pull out the PDA, the camera shifts
forward to the centered position on the player's neck. This patch
removes that behavior so that the camera is always positioned on the
player neck even when the PDA is not active.

This change also bypasses some code that sets a clipping value that was
causing the player body to be clipped nearby, so now looking down at the
body won't cause clipping visuals and instead you'll see the player body
unless you move your head actually inside of the body.